### PR TITLE
Fix the wrong name being showed

### DIFF
--- a/src/main/java/com/lyttledev/lyttlegravestone/listeners/RightClick.java
+++ b/src/main/java/com/lyttledev/lyttlegravestone/listeners/RightClick.java
@@ -52,11 +52,11 @@ public class RightClick implements Listener {
             String graveOwnerString = values[0];
             Player graveOwnerPlayer = Bukkit.getPlayer(UUID.fromString(graveOwnerString));
             OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(UUID.fromString(graveOwnerString));
-            String graveOwnerName = graveOwnerPlayer != null ? graveOwnerPlayer.getName() : offlinePlayer.getName();
+            String graveOwnerName = graveOwnerPlayer != null ? getDisplayName(graveOwnerPlayer) : offlinePlayer.getName();
 
             // Permission logic
             if (player != graveOwnerPlayer && !player.hasPermission("lyttlegravestone.Staff")) {
-                String[][] replacements = {{"<PLAYER>", getDisplayName(player)}};
+                String[][] replacements = {{"<PLAYER>", graveOwnerName}};
                 Message.sendMessage(player, "wrong_player", replacements);
                 return;
             }


### PR DESCRIPTION
When right clicking on a grave that isn't yours it still says its yours.
Although you there was no access and no items could be stole, was it still an annoyance.