### PR TITLE
Fix/dupe in claims

### DIFF
--- a/src/main/java/com/lyttledev/lyttlegravestone/listeners/Death.java
+++ b/src/main/java/com/lyttledev/lyttlegravestone/listeners/Death.java
@@ -39,6 +39,7 @@ public class Death implements Listener {
         ItemStack[] gravestoneInventory = setLayout(playerInventory, cursorItem);
         player.setItemOnCursor(null);
         event.getDrops().clear();
+        playerInventory.clear();
         Location playerLocation = player.getLocation();
 
         // Check if the location is safe!


### PR DESCRIPTION
When in a claim that does not allow for dropping items and the player happens to die
the items stayed in the inventory and were also duplicated to the DB
Added a line of code to clear that inventory