### PR TITLE
Prevent duping via spamming the message in chat

### DIFF
--- a/src/main/java/com/lyttledev/lyttlegravestone/utils/Memory.java
+++ b/src/main/java/com/lyttledev/lyttlegravestone/utils/Memory.java
@@ -40,4 +40,20 @@ public class Memory {
         }
         return -1;
     }
+
+
+    // Keeps track of deliveries in progress
+    private static final List<Player> deliveriesInProgress = new ArrayList<>();
+
+    public static void addDelivery(Player player) { deliveriesInProgress.add(player); }
+
+    public static void removeDelivery(Player player) { deliveriesInProgress.remove(player); }
+
+    public static boolean checkDelivery(Player player) {
+        for (Player playerEntry : deliveriesInProgress) {
+            if (playerEntry.equals(player)) { return true; }
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
This does fix the dupe, but introduces a know bug that I can't seem to find.
When spam clicking the message it keeps your entry in the Memory class array.
This prevents you from starting a new delivery, this is obviously better then the dupe itself!