### PR TITLE
Fixes the potential error

### DIFF
--- a/src/main/java/com/lyttledev/lyttlegravestone/listeners/GuiClose.java
+++ b/src/main/java/com/lyttledev/lyttlegravestone/listeners/GuiClose.java
@@ -56,6 +56,8 @@ public class GuiClose implements Listener {
         Location location = Memory.getGravestoneLocation(player);
         Memory.closeGravestone(player, location);
 
+        if (location == null) { return; }
+
         boolean isEmpty = true;
         for (ItemStack item : gravestoneInventory) {
             if (item != null) {


### PR DESCRIPTION
When closing a shulker GUI that has the right name it would throw an error because the location is not know as a grave in the memory class.