### PR TITLE
Update lytleutils to version 1.2.1 and bump plugin version to 1.3.6; …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     compileOnly("io.papermc.paper:paper-api:" + (property("paperVersion") as String) + "-R0.1-SNAPSHOT")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7") { exclude(group = "org.bukkit", module = "bukkit") }
     compileOnly("org.xerial:sqlite-jdbc:3.46.0.0")
-    implementation("com.lyttledev:lyttleutils:1.2.0")
+    implementation("com.lyttledev:lyttleutils:1.2.1")
 }
 
 group = "com.lyttledev"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # The current version of the plugin.
-pluginVersion=1.3.5
+pluginVersion=1.3.6
 
 # Specify the platform versions for Paper, Velocity, and Waterfall.
 # Hangar also allows version ranges (such as 1.19-1.20.2) and wildcards (such as 1.20.x).
-paperVersion=1.21.8
+paperVersion=1.21.11


### PR DESCRIPTION
This pull request updates the plugin version and the supported Paper platform version in the `gradle.properties` file.

Version updates:

* Bumped `pluginVersion` from `1.3.5` to `1.3.6` to reflect a new release.
* Updated `paperVersion` from `1.21.8` to `1.21.11` to support the latest Paper platform version.